### PR TITLE
Raise error when JSON is invalid

### DIFF
--- a/lib/jekyll-shields_io.rb
+++ b/lib/jekyll-shields_io.rb
@@ -116,9 +116,11 @@ module Jekyll
     end
 
     # Jekyll Liquid Tag for Shields.io
-    #
     # Usage: {% shields_io <query param + special param as json> %}
     class ShieldsIOTag < Liquid::Tag
+      # @param [String] tag_name == shields_io
+      # @param [String] input User input
+      # @param [Liquid::Context] parse_context
       def initialize(tag_name, input, parse_context)
         super
         # @type [Hash]
@@ -126,6 +128,9 @@ module Jekyll
         # This only appears if there is an error trying to fetch the shield.
         # @type [String]
         @last_ditch_alt = "<p>#{@payload[:label]} #{@payload[:message]}</p>"
+      rescue JSON::ParserError => pe
+        warn "[Shields.IO Plugin] Shield configuration is malformed (#{pe.message})"
+        raise ShieldConfigMalformedError
       end
 
       def render(context)

--- a/lib/jekyll-shields_io/domain.rb
+++ b/lib/jekyll-shields_io/domain.rb
@@ -57,6 +57,13 @@ module Jekyll
       end
     end
 
+    # Thrown when the plugin encounters malformed input.
+    class ShieldConfigMalformedError < StandardError
+      def initialize(msg = "Malformed configuration was passed to the plugin")
+        super
+      end
+    end
+
     # Thrown when the plugin fails to fetch the shield image.
     class ShieldFetchError < StandardError
     end

--- a/spec/jekyll-shields_io_spec.rb
+++ b/spec/jekyll-shields_io_spec.rb
@@ -121,16 +121,18 @@ RSpec.describe "Integration test" do
   context "When invalid JSON is passed" do
     it "fails with exception" do
       t = Liquid::Template.new
-      expect { t.parse(
-        <<~EOT
-          {% shield_io {this is invalid!} %}
-      EOT
-      ) }.to raise_error Jekyll::ShieldsIO::ShieldConfigMalformedError
+      expect {
+        t.parse(
+          <<~EOT
+            {% shield_io {this is invalid!} %}
+        EOT
+        )
+      }.to raise_error Jekyll::ShieldsIO::ShieldConfigMalformedError
     end
   end
 
   after do
-    if File.exists? @cache_dir
+    if File.exist? @cache_dir
       FileUtils.rm_r @cache_dir
     end
   end

--- a/spec/jekyll-shields_io_spec.rb
+++ b/spec/jekyll-shields_io_spec.rb
@@ -118,7 +118,20 @@ RSpec.describe "Integration test" do
     end
   end
 
+  context "When invalid JSON is passed" do
+    it "fails with exception" do
+      t = Liquid::Template.new
+      expect { t.parse(
+        <<~EOT
+          {% shield_io {this is invalid!} %}
+      EOT
+      ) }.to raise_error Jekyll::ShieldsIO::ShieldConfigMalformedError
+    end
+  end
+
   after do
-    FileUtils.rm_r @cache_dir
+    if File.exists? @cache_dir
+      FileUtils.rm_r @cache_dir
+    end
   end
 end


### PR DESCRIPTION
Logs and raises Jekyll::ShieldsIO::ShieldConfigMalformedError if passed input is invalid