### PR TITLE
Refactor

### DIFF
--- a/lib/jekyll-shields_io.rb
+++ b/lib/jekyll-shields_io.rb
@@ -62,9 +62,6 @@ module Jekyll
       # @param [Shield] shield Shield to queue for this Jekyll site's Jekyll::StaticFile.
       # @raise [ShieldFileError] when specified cache file does not exist
       def queue_shield(shield)
-        unless File.exist? shield.path
-          raise ShieldFileError.new
-        end
         if @site.static_files.select { |f|
           f.is_a? StaticShieldFile
         }.select { |s| s.name == shield.basename }.any?
@@ -157,9 +154,6 @@ HTML
         end
       rescue ShieldFetchError
         warn "[Shields.IO Plugin] Failed to fetch shields! (input: #{JSON.dump @payload})"
-        @last_ditch_alt
-      rescue ShieldFileError
-        warn "[Shields.IO Plugin] Failed to access cached shields!"
         @last_ditch_alt
       end
     end

--- a/lib/jekyll-shields_io/domain.rb
+++ b/lib/jekyll-shields_io/domain.rb
@@ -67,11 +67,5 @@ module Jekyll
     # Thrown when the plugin fails to fetch the shield image.
     class ShieldFetchError < StandardError
     end
-
-    # Thrown when the plugin fails to access the cached shield file.
-    # Realistically, if this happens something must be very wrong with the disk the cache is written to
-    # because the plugin would've crashed with IO errors well before this is thrown.
-    class ShieldFileError < StandardError
-    end
   end
 end

--- a/spec/jekyll-shields_io_spec.rb
+++ b/spec/jekyll-shields_io_spec.rb
@@ -20,7 +20,22 @@ class ShieldsIOTagForTest < Jekyll::ShieldsIO::ShieldsIOTag
   attr_reader :factory
 end
 
-RSpec.describe "Jekyll::ShieldsIO::ShieldFactory" do
+RSpec.describe Jekyll::ShieldsIO::StaticShieldFile.name do
+  describe "destination" do
+    before do
+      site = Jekyll::Site.new(Jekyll.configuration({"source" => Jekyll::Configuration::DEFAULTS[:source], "skip_config_files" => true}))
+      @dest = File.join("_cache", "shields_io")
+      @basename = "basename.svg"
+      @shield_file = Jekyll::ShieldsIO::StaticShieldFile.new site, site.source, File.join("_cache", "shields_io"), @basename, @dest
+    end
+    it "can output expected destination" do
+      dest = @shield_file.destination "dest_folder"
+      expect(dest).to eq File.join("dest_folder", @dest, @basename)
+    end
+  end
+end
+
+RSpec.describe Jekyll::ShieldsIO::ShieldFactory.name do
   before do
     # Mocked configuration values
     @context = Liquid::Context.new({}, {}, {
@@ -149,7 +164,7 @@ RSpec.describe "Jekyll::ShieldsIO::ShieldFactory" do
   end
 end
 
-RSpec.describe "Jekyll::ShieldsIO::ShieldsIOTag" do
+RSpec.describe Jekyll::ShieldsIO::ShieldsIOTag.name do
   before do
     @context = Liquid::Context.new({}, {}, {
       site: Jekyll::Site.new(Jekyll.configuration({"source" => "", "skip_config_files" => true}))


### PR DESCRIPTION
* Remove an exception that was not too relevant
* Refactor test labels (use `.name` accessor to get the class names for `describe`)
* Add missing test for `StaticShieldFile.destination`